### PR TITLE
Remove field codigo_pagamento

### DIFF
--- a/nfce/schema/create_nfce_request_schema.yaml
+++ b/nfce/schema/create_nfce_request_schema.yaml
@@ -320,12 +320,6 @@ root:
               description: number of installments
               examples:
                 - 2
-            codigo_pagamento:
-              type: number
-              required: if uf == CE and tipo_integracao == 1
-              description: number of payment
-              examples:
-                - 12345
             valor_pagamento:
               type: number
               required: if uf == CE and tipo_integracao == 1


### PR DESCRIPTION
[#168785607](https://www.pivotaltracker.com/story/show/168785607)

- `numero_autorizacao_operacao` é obrigatório. Nós utilizaremos o mesmo valor desse campo para preencher os atributos `CodigoAutorizacao` e `NumeroDeAprovacao`.

- `nsu` é obrigatório. Nós utilizaremos o mesmo valor desse campo para preencher o atributo `CodigoPagamento`.