### PR TITLE
Para NFC-e, inserir na documentação da API a obrigatoriedade condicional por UF dos atributos cnpj_credenciadora, bandeira_operadora e numero_autorizacao_operacao

### DIFF
--- a/nfce/schema/create_nfce_request_schema.yaml
+++ b/nfce/schema/create_nfce_request_schema.yaml
@@ -249,11 +249,15 @@ root:
                 - 2 # nao integrado (non-integrated)
             cnpj_credenciadora:
               <<: *t_cnpj
-              required: if uf == CE
+              required: if uf == CE or uf == PE or uf == RN or uf == AL 
+                        or uf == BA or uf == ES or uf == MS or uf == PB
+                        or uf == PR or uf == RJ or uf == TO
               description: card acreditation authority's national registration
             bandeira_operadora:
               type: enum[string]
-              required: if uf == CE
+              required: if uf == CE or uf == PE or uf == RN or uf == AL 
+                        or uf == BA or uf == ES or uf == MS or uf == PB
+                        or uf == PR or uf == RJ or uf == TO
               description: >
                 see https://myfreecomm.github.io/emites-api-docs/#cartao-xml-card
               enum:
@@ -269,7 +273,9 @@ root:
                 - "99" # OUTROS (other)
             numero_autorizacao_operacao:
               type: string
-              required: true
+              required: if uf == CE or uf == PE or uf == RN or uf == AL 
+                        or uf == BA or uf == ES or uf == MS or uf == PB
+                        or uf == PR or uf == RJ or uf == TO
               description: transation authorization ID
               max_length: 20
               examples:

--- a/nfce/schema/create_nfce_request_schema.yaml
+++ b/nfce/schema/create_nfce_request_schema.yaml
@@ -249,15 +249,11 @@ root:
                 - 2 # nao integrado (non-integrated)
             cnpj_credenciadora:
               <<: *t_cnpj
-              required: if uf == CE or uf == PE or uf == RN or uf == AL 
-                        or uf == BA or uf == ES or uf == MS or uf == PB
-                        or uf == PR or uf == RJ or uf == TO
+              required: if uf in (CE, PE, RN, AL, BA, ES, MS, PB, PR, RJ, TO)
               description: card acreditation authority's national registration
             bandeira_operadora:
               type: enum[string]
-              required: if uf == CE or uf == PE or uf == RN or uf == AL 
-                        or uf == BA or uf == ES or uf == MS or uf == PB
-                        or uf == PR or uf == RJ or uf == TO
+              required: if uf in (CE, PE, RN, AL, BA, ES, MS, PB, PR, RJ, TO)
               description: >
                 see https://myfreecomm.github.io/emites-api-docs/#cartao-xml-card
               enum:
@@ -273,9 +269,7 @@ root:
                 - "99" # OUTROS (other)
             numero_autorizacao_operacao:
               type: string
-              required: if uf == CE or uf == PE or uf == RN or uf == AL 
-                        or uf == BA or uf == ES or uf == MS or uf == PB
-                        or uf == PR or uf == RJ or uf == TO
+              required: if uf in (CE, PE, RN, AL, BA, ES, MS, PB, PR, RJ, TO)
               description: transation authorization ID
               max_length: 20
               examples:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/169985933